### PR TITLE
installation_repositories event action fix

### DIFF
--- a/src/GitHub/Data/Webhooks/Events.hs
+++ b/src/GitHub/Data/Webhooks/Events.hs
@@ -397,8 +397,8 @@ instance NFData InstallationEvent where rnf = genericRnf
 
 
 data InstallationRepoEventAction
-  -- | Decodes from "created"
-  = InstallationRepoCreatedAction
+  -- | Decodes from "added"
+  = InstallationRepoAddedAction
   -- | Decodes from "removed"
   | InstallationRepoRemovedAction
   -- | The result of decoding an unknown installation repo event action type
@@ -410,7 +410,7 @@ instance NFData InstallationRepoEventAction where rnf = genericRnf
 instance FromJSON InstallationRepoEventAction where
   parseJSON = withText "Installation repo event action" $ \t ->
     case t of
-        "created"       -> pure InstallationRepoCreatedAction
+        "added"         -> pure InstallationRepoAddedAction
         "removed"       -> pure InstallationRepoRemovedAction
         _               -> pure (InstallationRepoActionOther t)
 


### PR DESCRIPTION
It should be `added` not `created`.

See https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#installation_repositories

**Issue reference:**
Fixes #39

**Submission Checklist:**
* [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document (for example, is your tree a clean merge)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission build?
* [x] Does your submission pass tests?
* [x] Have you run lints on your code locally prior to submission?
* [x] Have you updated *all* of the cabal/nix infrastructure?
* [x] Is this a breaking change? Have you discussed this?

<!-- Please tag a maintainer if you don't get a response within a reasonable period of time -->
