### PR TITLE
Support additional installation event actions

### DIFF
--- a/src/GitHub/Data/Webhooks/Events.hs
+++ b/src/GitHub/Data/Webhooks/Events.hs
@@ -369,6 +369,12 @@ data InstallationEventAction
   = InstallationCreatedAction
   -- | Decodes from "deleted"
   | InstallationDeletedAction
+  -- | Decodes from "suspend"
+  | InstallationSuspendAction
+  -- | Decodes from "unsuspend"
+  | InstallationUnsuspendAction
+  -- | Decodes from "new_permissions_accepted"
+  | InstallationNewPermissionsAcceptedAction
   -- | The result of decoding an unknown installation event action type
   | InstallationActionOther !Text
   deriving (Eq, Ord, Show, Generic, Typeable, Data)
@@ -378,9 +384,12 @@ instance NFData InstallationEventAction where rnf = genericRnf
 instance FromJSON InstallationEventAction where
   parseJSON = withText "Installation event action" $ \t ->
     case t of
-        "created"       -> pure InstallationCreatedAction
-        "deleted"       -> pure InstallationDeletedAction
-        _               -> pure (InstallationActionOther t)
+        "created"                  -> pure InstallationCreatedAction
+        "deleted"                  -> pure InstallationDeletedAction
+        "suspend"                  -> pure InstallationSuspendAction
+        "unsuspend"                -> pure InstallationUnsuspendAction
+        "new_permissions_accepted" -> pure InstallationNewPermissionsAcceptedAction
+        _                          -> pure (InstallationActionOther t)
 
 -- | Triggered when a GitHub App has been installed or uninstalled.
 -- See <https://developer.github.com/v3/activity/events/types/#installationevent>.


### PR DESCRIPTION
Add missing installation event actions from https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#installation

**Issue reference:**
<!-- Which issue(s) does this solve? Do you need to make one? -->

Seems pretty straight forward. Should I create an issue?

**Submission Checklist:**
* [x] Have you followed the guidelines in our [Contributing](../../CONTRIBUTING.md) document (for example, is your tree a clean merge)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission build?
* [x] Does your submission pass tests?
* [x] Have you run lints on your code locally prior to submission?
* [x] Have you updated *all* of the cabal/nix infrastructure?
* [x] Is this a breaking change? Have you discussed this?

<!-- Please tag a maintainer if you don't get a response within a reasonable period of time -->
